### PR TITLE
Fix '/bin/sh: 1: [[: not found' on make link.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL=/bin/bash
+
 version = 0.1
 
 bindir = /usr/bin


### PR DESCRIPTION
Cause: `[[` is a bashism, not portable sh. Recent bash, when run as `/bin/sh` do not know `[[` for the sake of compliance.
Solution: either live with bash and say it (accept this pull request).
Or review the Makefile, remove all bashism, test with strict conditions, etc.
Fixes https://github.com/dagwieers/asciidoc-odf/issues/40
