### PR TITLE
Create archive sub-directories when required

### DIFF
--- a/backends/odp/a2x-backend.py
+++ b/backends/odp/a2x-backend.py
@@ -54,6 +54,9 @@ class odp_archive:
 					for cl in cxf:
 						mc = ire.match(cl)
 						if mc is not None:
+							dstdir = os.path.dirname(os.path.join(td, mc.group(2)))
+							if not os.path.exists(dstdir):
+								os.makedirs(dstdir)
 							shutil.copyfile(mc.group(1), os.path.join(td, mc.group(2)))
 							nmf.write('\n <manifest:file-entry manifest:media-type="image/%s" manifest:full-path="%s"/>' %
 								(supported_extensions[os.path.splitext(mc.group(2))[1]],

--- a/backends/odt/a2x-backend.py
+++ b/backends/odt/a2x-backend.py
@@ -58,6 +58,9 @@ class odt_archive:
 					for cl in cxf:
 						mc = ire.match(cl)
 						if mc is not None:
+							dstdir = os.path.dirname(os.path.join(td, mc.group(2)))
+							if not os.path.exists(dstdir):
+								os.makedirs(dstdir)
 							shutil.copyfile(mc.group(1), os.path.join(td, mc.group(2)))
 							nmf.write('\n <manifest:file-entry manifest:media-type="image/%s" manifest:full-path="%s"/>' %
 								(supported_extensions[os.path.splitext(mc.group(2))[1]],


### PR DESCRIPTION
When generating a document containing embedded images, an IOError
would be raised when copying the image file into the Pictures/
sub-directory of the archive because the directory would not exist.

This commits allows the backend to verify the directory's existence on
creation, and creates it if needed. This fixes dagwieers/asciidoc-odf#42.