### PR TITLE
Allow dates with spaces in them

### DIFF
--- a/backends/odt/odt.conf
+++ b/backends/odt/odt.conf
@@ -739,8 +739,8 @@ ifndef::not_flat_odf[]
  <dc:subject>{description}</dc:subject>
  <dc:description>{description}</dc:description>
  <dc:creator>{author}</dc:creator>
- <meta:creation-date>{sys:date --date={revdate={docdate}} +%Y-%m-%dT%H:%M:%S 2>/dev/null}</meta:creation-date>
- <dc:date>{sys:date --date={docdate={revdate}} +%Y-%m-%dT%H:%M:%S 2>/dev/null}</dc:date>
+ <meta:creation-date>{sys:date --date="{revdate={docdate}}" +%Y-%m-%dT%H:%M:%S 2>/dev/null}</meta:creation-date>
+ <dc:date>{sys:date --date="{docdate={revdate}}" +%Y-%m-%dT%H:%M:%S 2>/dev/null}</dc:date>
  <dc:language>{lang=en}</dc:language>
  <meta:initial-creator>{author}{email? &lt;{email}&gt;}</meta:initial-creator>
  <meta:generator>AsciiDoc {asciidoc-version}</meta:generator>


### PR DESCRIPTION
If a date had a space in it (such as September 29, 2017), asciidoc would emit a warning that sys:date had a non-zero exit status.